### PR TITLE
Potential fix for code scanning alert no. 87: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     name: Prepare Release
     runs-on: ubuntu-latest
     needs: validate
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag_version: ${{ steps.version.outputs.tag_version }}


### PR DESCRIPTION
Potential fix for [https://github.com/rust84/kubesearch-mcp-server/security/code-scanning/87](https://github.com/rust84/kubesearch-mcp-server/security/code-scanning/87)

In general, the problem is fixed by adding an explicit `permissions` block to the affected job (or the workflow root) to restrict the `GITHUB_TOKEN` to the minimal scopes it actually needs. For the `prepare` job, it only checks out the repository and reads files, so it needs at most read access to repository contents; no write scopes appear necessary.

The best minimal fix without changing any existing behavior is to add a `permissions` block under the `prepare` job, at the same indentation level as `runs-on`, `needs`, and `outputs`. We will set `contents: read`, which is sufficient for `actions/checkout@v4` and read-only operations. No other scopes (like `packages`, `pull-requests`, etc.) are required here because the job does not perform writes to GitHub resources. Concretely, within `.github/workflows/release.yml`, we will insert:

```yaml
    permissions:
      contents: read
```

between `needs: validate` and `outputs:` for the `prepare` job. No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
