### PR TITLE
Potential fix for code scanning alert no. 86: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   validate:
     name: Validate Code Quality
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/rust84/kubesearch-mcp-server/security/code-scanning/86](https://github.com/rust84/kubesearch-mcp-server/security/code-scanning/86)

In general, the fix is to explicitly declare `permissions` for the workflow or job so that the `GITHUB_TOKEN` has only the access that the job actually needs. For the `validate` job shown, the steps only read repository contents and run local commands; they do not push code, modify issues, or upload security events. Therefore, setting `contents: read` is sufficient and follows the least-privilege principle.

The best minimal fix, without altering any existing behavior, is to add a `permissions` block to the `validate` job. This keeps the existing `security-scan` job’s explicit permissions unchanged and avoids assumptions about other workflows. Concretely, in `.github/workflows/ci.yml`, under `jobs:`, in the `validate:` job definition (around lines 17–22), add:

```yaml
    permissions:
      contents: read
```

indented to align with `runs-on` and `outputs`. No new imports or external dependencies are required; this is purely a YAML configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
